### PR TITLE
更新 StoreController 以使用分頁，修改 Store 模型的關聯，並改善 useApi 中的用戶獲取邏輯

### DIFF
--- a/inventory-api/app/Http/Controllers/Api/StoreController.php
+++ b/inventory-api/app/Http/Controllers/Api/StoreController.php
@@ -35,10 +35,8 @@ class StoreController extends Controller
      */
     public function index(): AnonymousResourceCollection
     {
--        $stores = Store::all();
--        return StoreResource::collection($stores);
-+        $stores = Store::paginate(15);
-+        return StoreResource::collection($stores);
+        $stores = Store::paginate(15);
+        return StoreResource::collection($stores);
     }
 
     /**

--- a/inventory-api/app/Models/Store.php
+++ b/inventory-api/app/Models/Store.php
@@ -19,9 +19,8 @@ class Store extends Model
      */
     public function users()
     {
--        return $this->belongsToMany(User::class);
-+        return $this->belongsToMany(User::class, 'store_user')
-+            ->withTimestamps();   // if pivot tracks created_at/updated_at
+        return $this->belongsToMany(User::class, 'store_user')
+            ->withTimestamps();   // if pivot tracks created_at/updated_at
     }
 
     /**

--- a/inventory-client/src/app/(app)/users/page.tsx
+++ b/inventory-client/src/app/(app)/users/page.tsx
@@ -95,6 +95,7 @@ export default function UsersPage() {
   const [isStoresDialogOpen, setIsStoresDialogOpen] = useState(false);
   const [selectedUserForStores, setSelectedUserForStores] = useState<User | null>(null);
 
+  // 處理分店管理按鈕點擊
   const handleManageUserStores = (user: User) => {
     setSelectedUserForStores(user);
     setIsStoresDialogOpen(true);
@@ -108,15 +109,6 @@ export default function UsersPage() {
     }
   };
 
-  // … later in your render …
-  {selectedUserForStores && (
-    <UserStoresDialog
-      open={isStoresDialogOpen}
-      user={selectedUserForStores}
-      onOpenChange={handleStoresDialogOpenChange}
-      /* …other props… */
-    />
-  )}
   /**
    * 處理創建新用戶的函式
    * 
@@ -289,14 +281,6 @@ export default function UsersPage() {
     if (!open) {
       resetEditForm(); // 關閉時重置編輯表單
     }
-  };
-
-  /**
-   * 處理管理用戶分店按鈕點擊
-   */
-  const handleManageUserStores = (user: User) => {
-    setSelectedUserForStores(user);
-    setIsStoresDialogOpen(true);
   };
 
   /**

--- a/inventory-client/src/hooks/useApi.ts
+++ b/inventory-client/src/hooks/useApi.ts
@@ -262,16 +262,17 @@ export function useUsers(filters?: UserQueryParams) {
         include: 'stores',
       };
       
-      // …rest of the function
-    }
-      const { data, error } = await apiClient.GET('/api/users', {
+      const response = await apiClient.GET('/api/users', {
         params: { query: queryParams },
       });
-      if (error) { throw new Error('獲取用戶列表失敗'); }
+      
+      if (response.error) { 
+        throw new Error('獲取用戶列表失敗'); 
+      }
       
       // 確保返回資料結構統一，處理 Laravel 分頁結構
       // 分頁響應結構: { data: [...用戶列表], meta: {...分頁資訊} }
-      return data;
+      return response.data;
     },
   });
 }


### PR DESCRIPTION
此拉取請求引入了多項更新，旨在改進分頁功能、增強關聯性並重構 API 和客戶端應用程式中的程式碼。主要變更包括在 `StoreController` 中新增分頁功能、更新 `Store` 模型的關聯定義，以及重構客戶端應用程式中的 `UsersPage` 元件和 `useUsers` 掛鉤，以提升功能性和可維護性。

### 後端變更

**分頁與關聯性：**
- 更新 `StoreController` 中的 `index` 方法，使用分頁 (`paginate(15)`) 而非一次擷取所有商店 (`Store::all()`)，從而改善處理大型資料集時的可擴展性。(`[inventory-api/app/Http/Controllers/Api/StoreController.phpL38-R39](diffhunk://#diff-1cb5d1ec20d452ac540fab489b8547b3fde020ea76b8ec42194b76fc3dba5957L38-R39)`)
- 修改 `Store` 模型的 `users` 關聯，以指定中介資料表 (`store_user`) 並包含時間戳記 (`withTimestamps()`)，確保準確追蹤關聯變更。(`[inventory-api/app/Models/Store.phpL22-R23](diffhunk://#diff-8d30a31f6b4eb6f9f535a3d36fe0712e416370fc0f3a4fee14d15f5801bb676fL22-R23)`)

### 前端變更

**UsersPage 元件重構：**
- 移除了與管理使用者商店相關的未使用程式碼（`handleManageUserStores` 函數和 `UserStoresDialog` 元件），精簡了 `UsersPage` 元件。(`[[1]](diffhunk://#diff-4a1c4b213d503ab5d7baf2fc519eb5132fb238039fbdf3d05774df325c95a6e9L111-L119)`、`[[2]](diffhunk://#diff-4a1c4b213d503ab5d7baf2fc519eb5132fb238039fbdf3d05774df325c95a6e9L294-L301)`)

**API 掛鉤更新：**
- 重構 `useUsers` 掛鉤以更穩健地處理 API 回應，確保在處理來自 Laravel 的分頁結果時，能有適當的錯誤處理和一致的資料結構。(`[inventory-client/src/hooks/useApi.tsL265-R275](diffhunk://#diff-cb2499d156c5a7436924963c8fcdf1f9e91633f9ccf410bf519f722d2bd68629L265-R275)`)