### PR TITLE
feat: 使用 API 端點、模型、策略和服務實現安裝管理系統

### DIFF
--- a/inventory-api/app/Http/Controllers/Api/AttributeValueController.php
+++ b/inventory-api/app/Http/Controllers/Api/AttributeValueController.php
@@ -98,7 +98,7 @@ class AttributeValueController extends Controller
      * @authenticated
      * @urlParam value integer required 要更新的屬性值的 ID。 Example: 1
      * @bodyParam value string required 新的屬性值。 Example: "深藍色"
-     * @responseFile storage/responses/attribute_value.show.json
+     * @response 200 App\Http\Resources\Api\AttributeValueResource
      */
     public function update(UpdateAttributeValueRequest $request, AttributeValue $value)
     {

--- a/inventory-api/app/Http/Controllers/Api/InstallationController.php
+++ b/inventory-api/app/Http/Controllers/Api/InstallationController.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\StoreInstallationRequest;
+use App\Http\Requests\Api\UpdateInstallationRequest;
+use App\Http\Requests\Api\CreateInstallationFromOrderRequest;
+use App\Http\Resources\Api\InstallationResource;
+use App\Models\Installation;
+use App\Services\InstallationService;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use Spatie\QueryBuilder\QueryBuilder;
+use Spatie\QueryBuilder\AllowedFilter;
+
+/**
+ * @group 安裝管理
+ * 
+ * 管理安裝單的相關 API
+ */
+class InstallationController extends Controller
+{
+    /**
+     * @var InstallationService
+     */
+    private InstallationService $installationService;
+
+    /**
+     * 建構子
+     */
+    public function __construct(InstallationService $installationService)
+    {
+        $this->installationService = $installationService;
+    }
+
+    /**
+     * 獲取安裝單列表
+     * 
+     * @queryParam filter[status] 按狀態篩選。可選值：pending, scheduled, in_progress, completed, cancelled。Example: pending
+     * @queryParam filter[installer_user_id] 按安裝師傅篩選。Example: 1
+     * @queryParam filter[scheduled_date] 按預計安裝日期篩選。Example: 2025-06-24
+     * @queryParam filter[customer_name] 按客戶姓名篩選（模糊搜尋）。Example: 王小明
+     * @queryParam filter[installation_number] 按安裝單號篩選。Example: I-202506-0001
+     * @queryParam include 包含關聯資源。可選值：items,order,installer,creator。Example: items,order
+     * @queryParam sort 排序欄位。可選值：created_at,-created_at,scheduled_date,-scheduled_date。Example: -created_at
+     * @queryParam per_page 每頁顯示筆數。Example: 15
+     * 
+     * @authenticated
+     * @response 200 {
+     *   "data": [{
+     *     "id": 1,
+     *     "installation_number": "I-202506-0001",
+     *     "customer_name": "王小明",
+     *     "status": "pending",
+     *     "scheduled_date": "2025-06-25"
+     *   }],
+     *   "meta": {
+     *     "current_page": 1,
+     *     "total": 10
+     *   }
+     * }
+     */
+    public function index(Request $request)
+    {
+        $this->authorize('viewAny', Installation::class);
+
+        $query = QueryBuilder::for(Installation::class)
+            ->allowedIncludes(['items', 'order', 'installer', 'creator'])
+            ->allowedFilters([
+                AllowedFilter::exact('status'),
+                AllowedFilter::exact('installer_user_id'),
+                AllowedFilter::exact('scheduled_date'),
+                AllowedFilter::partial('customer_name'),
+                AllowedFilter::partial('installation_number'),
+            ])
+            ->allowedSorts(['created_at', 'scheduled_date'])
+            ->defaultSort('-created_at');
+
+        // 如果是安裝師傅，只能看到分配給自己的安裝單
+        if ($request->user()->hasRole('installer') && !$request->user()->hasAnyRole(['admin', 'staff', 'viewer'])) {
+            $query->where('installer_user_id', $request->user()->id);
+        }
+
+        $installations = $query->paginate($request->input('per_page', 15));
+
+        return InstallationResource::collection($installations);
+    }
+
+    /**
+     * 建立新的安裝單
+     * 
+     * @bodyParam order_id integer 關聯的訂單ID（可選）。Example: 1
+     * @bodyParam installer_user_id integer 分配的安裝師傅ID（可選）。Example: 2
+     * @bodyParam customer_name string required 客戶姓名。Example: 王小明
+     * @bodyParam customer_phone string required 客戶電話。Example: 0912345678
+     * @bodyParam installation_address string required 安裝地址。Example: 台北市信義區信義路五段7號
+     * @bodyParam scheduled_date date 預計安裝日期（可選）。Example: 2025-06-25
+     * @bodyParam notes string 備註（可選）。Example: 請於下午2點後安裝
+     * @bodyParam items array required 安裝項目清單。
+     * @bodyParam items.*.product_name string required 商品名稱。Example: 辦公桌
+     * @bodyParam items.*.sku string required 商品編號。Example: DESK-001
+     * @bodyParam items.*.quantity integer required 數量。Example: 2
+     * @bodyParam items.*.specifications string 安裝規格說明（可選）。Example: 靠窗安裝
+     * 
+     * @authenticated
+     * @response 201 {
+     *   "data": {
+     *     "id": 1,
+     *     "installation_number": "I-202506-0001",
+     *     "customer_name": "王小明",
+     *     "status": "pending"
+     *   }
+     * }
+     */
+    public function store(StoreInstallationRequest $request)
+    {
+        $this->authorize('create', Installation::class);
+
+        $installation = $this->installationService->createInstallation(
+            $request->validated(),
+            $request->user()->id
+        );
+
+        return new InstallationResource($installation->load(['items']));
+    }
+
+    /**
+     * 從訂單建立安裝單
+     * 
+     * @bodyParam order_id integer required 訂單ID。Example: 1
+     * @bodyParam order_item_ids array required 要安裝的訂單項目ID清單。Example: [1, 2, 3]
+     * @bodyParam installer_user_id integer 分配的安裝師傅ID（可選）。Example: 2
+     * @bodyParam installation_address string 安裝地址（可選，預設使用訂單地址）。Example: 台北市信義區信義路五段7號
+     * @bodyParam scheduled_date date 預計安裝日期（可選）。Example: 2025-06-25
+     * @bodyParam notes string 備註（可選）。Example: 請於下午2點後安裝
+     * @bodyParam specifications array 安裝規格（按訂單項目ID）。Example: {"1": "靠窗安裝", "2": "靠牆安裝"}
+     * 
+     * @authenticated
+     * @response 201 {
+     *   "data": {
+     *     "id": 1,
+     *     "installation_number": "I-202506-0001",
+     *     "order_id": 1,
+     *     "customer_name": "王小明",
+     *     "status": "pending"
+     *   }
+     * }
+     */
+    public function createFromOrder(CreateInstallationFromOrderRequest $request)
+    {
+        $this->authorize('createFromOrder', Installation::class);
+
+        $validated = $request->validated();
+        
+        $installation = $this->installationService->createFromOrder(
+            $validated['order_id'],
+            $validated['order_item_ids'],
+            $validated,
+            $request->user()->id
+        );
+
+        return new InstallationResource($installation->load(['items', 'order']));
+    }
+
+    /**
+     * 查看安裝單詳情
+     * 
+     * @urlParam installation integer required 安裝單ID。Example: 1
+     * @queryParam include 包含關聯資源。可選值：items,order,installer,creator。Example: items,order
+     * 
+     * @authenticated
+     * @response 200 {
+     *   "data": {
+     *     "id": 1,
+     *     "installation_number": "I-202506-0001",
+     *     "customer_name": "王小明",
+     *     "status": "pending",
+     *     "items": [{
+     *       "id": 1,
+     *       "product_name": "辦公桌",
+     *       "quantity": 2
+     *     }]
+     *   }
+     * }
+     */
+    public function show(Request $request, Installation $installation)
+    {
+        $this->authorize('view', $installation);
+
+        $installation->loadMissing(
+            explode(',', $request->input('include', ''))
+        );
+
+        return new InstallationResource($installation);
+    }
+
+    /**
+     * 更新安裝單
+     * 
+     * @urlParam installation integer required 安裝單ID。Example: 1
+     * @bodyParam installer_user_id integer 分配的安裝師傅ID。Example: 2
+     * @bodyParam customer_name string 客戶姓名。Example: 王小明
+     * @bodyParam customer_phone string 客戶電話。Example: 0912345678
+     * @bodyParam installation_address string 安裝地址。Example: 台北市信義區信義路五段7號
+     * @bodyParam status string 狀態。可選值：pending, scheduled, in_progress, completed, cancelled。Example: scheduled
+     * @bodyParam scheduled_date date 預計安裝日期。Example: 2025-06-25
+     * @bodyParam actual_start_time datetime 實際開始時間。Example: 2025-06-25 09:00:00
+     * @bodyParam actual_end_time datetime 實際結束時間。Example: 2025-06-25 11:00:00
+     * @bodyParam notes string 備註。Example: 已完成安裝
+     * 
+     * @authenticated
+     * @response 200 {
+     *   "data": {
+     *     "id": 1,
+     *     "installation_number": "I-202506-0001",
+     *     "status": "scheduled"
+     *   }
+     * }
+     */
+    public function update(UpdateInstallationRequest $request, Installation $installation)
+    {
+        $this->authorize('update', $installation);
+
+        $installation = $this->installationService->updateInstallation(
+            $installation,
+            $request->validated()
+        );
+
+        return new InstallationResource($installation);
+    }
+
+    /**
+     * 刪除安裝單
+     * 
+     * @urlParam installation integer required 安裝單ID。Example: 1
+     * 
+     * @authenticated
+     * @response 204
+     */
+    public function destroy(Installation $installation)
+    {
+        $this->authorize('delete', $installation);
+
+        $installation->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * 分配安裝師傅
+     * 
+     * @urlParam installation integer required 安裝單ID。Example: 1
+     * @bodyParam installer_user_id integer required 安裝師傅用戶ID。Example: 2
+     * 
+     * @authenticated
+     * @response 200 {
+     *   "data": {
+     *     "id": 1,
+     *     "installer_user_id": 2,
+     *     "status": "scheduled"
+     *   }
+     * }
+     */
+    public function assignInstaller(Request $request, Installation $installation)
+    {
+        $this->authorize('assignInstaller', $installation);
+
+        $request->validate([
+            'installer_user_id' => ['required', 'integer', 'exists:users,id']
+        ]);
+
+        $installation = $this->installationService->assignInstaller(
+            $installation,
+            $request->installer_user_id
+        );
+
+        return new InstallationResource($installation->load('installer'));
+    }
+
+    /**
+     * 更新安裝單狀態
+     * 
+     * @urlParam installation integer required 安裝單ID。Example: 1
+     * @bodyParam status string required 新狀態。可選值：pending, scheduled, in_progress, completed, cancelled。Example: in_progress
+     * @bodyParam reason string 取消原因（當狀態為cancelled時）。Example: 客戶要求取消
+     * 
+     * @authenticated
+     * @response 200 {
+     *   "data": {
+     *     "id": 1,
+     *     "status": "in_progress",
+     *     "actual_start_time": "2025-06-25 09:00:00"
+     *   }
+     * }
+     */
+    public function updateStatus(Request $request, Installation $installation)
+    {
+        $this->authorize('updateStatus', $installation);
+
+        $request->validate([
+            'status' => ['required', 'string', 'in:pending,scheduled,in_progress,completed,cancelled'],
+            'reason' => ['required_if:status,cancelled', 'string']
+        ]);
+
+        if ($request->status === 'cancelled') {
+            $installation = $this->installationService->cancelInstallation(
+                $installation,
+                $request->reason
+            );
+        } else {
+            $installation = $this->installationService->updateStatus(
+                $installation,
+                $request->status
+            );
+        }
+
+        return new InstallationResource($installation);
+    }
+
+    /**
+     * 獲取安裝師傅的行程
+     * 
+     * @queryParam installer_user_id integer required 安裝師傅用戶ID。Example: 2
+     * @queryParam start_date date required 開始日期。Example: 2025-06-01
+     * @queryParam end_date date required 結束日期。Example: 2025-06-30
+     * 
+     * @authenticated
+     * @response 200 {
+     *   "data": [{
+     *     "id": 1,
+     *     "installation_number": "I-202506-0001",
+     *     "scheduled_date": "2025-06-25",
+     *     "customer_name": "王小明"
+     *   }]
+     * }
+     */
+    public function getSchedule(Request $request)
+    {
+        $this->authorize('viewAny', Installation::class);
+
+        $request->validate([
+            'installer_user_id' => ['required', 'integer', 'exists:users,id'],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['required', 'date', 'after_or_equal:start_date']
+        ]);
+
+        // 如果是安裝師傅角色，只能查看自己的行程
+        if ($request->user()->hasRole('installer') && !$request->user()->hasAnyRole(['admin', 'staff'])) {
+            if ($request->installer_user_id != $request->user()->id) {
+                abort(403, '您只能查看自己的安裝行程');
+            }
+        }
+
+        $installations = $this->installationService->getInstallerSchedule(
+            $request->installer_user_id,
+            new \DateTime($request->start_date),
+            new \DateTime($request->end_date)
+        );
+
+        return InstallationResource::collection($installations);
+    }
+} 

--- a/inventory-api/app/Http/Requests/Api/AddPaymentRequest.php
+++ b/inventory-api/app/Http/Requests/Api/AddPaymentRequest.php
@@ -90,4 +90,33 @@ class AddPaymentRequest extends FormRequest
             ]);
         }
     }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'amount' => [
+                'description' => '付款金額',
+                'example' => 5000.00,
+            ],
+            'payment_method' => [
+                'description' => '付款方式（cash: 現金, transfer: 轉帳, credit_card: 信用卡）',
+                'example' => 'cash',
+            ],
+            'payment_date' => [
+                'description' => '付款日期（可選，預設為當前時間）',
+                'example' => '2025-06-24',
+            ],
+            'notes' => [
+                'description' => '付款備註（可選）',
+                'example' => '第一期款項',
+            ],
+        ];
+    }
 }

--- a/inventory-api/app/Http/Requests/Api/BatchDeleteOrdersRequest.php
+++ b/inventory-api/app/Http/Requests/Api/BatchDeleteOrdersRequest.php
@@ -49,4 +49,21 @@ class BatchDeleteOrdersRequest extends FormRequest
             'ids.*.exists' => '選擇的訂單不存在或已被刪除',
         ];
     }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'ids' => [
+                'description' => '要刪除的訂單 ID 陣列',
+                'example' => [1, 2, 3],
+            ],
+        ];
+    }
 }

--- a/inventory-api/app/Http/Requests/Api/BatchUpdateStatusRequest.php
+++ b/inventory-api/app/Http/Requests/Api/BatchUpdateStatusRequest.php
@@ -60,4 +60,33 @@ class BatchUpdateStatusRequest extends FormRequest
             'notes.max' => '備註不能超過 500 個字符',
         ];
     }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'ids' => [
+                'description' => '要更新狀態的訂單 ID 陣列',
+                'example' => [1, 2, 3],
+            ],
+            'status_type' => [
+                'description' => '要更新的狀態類型（payment_status: 付款狀態, shipping_status: 貨物狀態）',
+                'example' => 'payment_status',
+            ],
+            'status_value' => [
+                'description' => '新的狀態值',
+                'example' => 'paid',
+            ],
+            'notes' => [
+                'description' => '狀態更新備註（可選）',
+                'example' => '已收到付款',
+            ],
+        ];
+    }
 } 

--- a/inventory-api/app/Http/Requests/Api/CreateInstallationFromOrderRequest.php
+++ b/inventory-api/app/Http/Requests/Api/CreateInstallationFromOrderRequest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateInstallationFromOrderRequest extends FormRequest
+{
+    /**
+     * 判斷用戶是否有權限發出此請求
+     */
+    public function authorize(): bool
+    {
+        return true; // 實際權限檢查在 Controller 中進行
+    }
+
+    /**
+     * 獲取適用於該請求的驗證規則
+     */
+    public function rules(): array
+    {
+        return [
+            'order_id' => ['required', 'integer', 'exists:orders,id'],
+            'installer_user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'installation_address' => ['nullable', 'string'], // 可選，如果不提供則使用訂單地址
+            'scheduled_date' => ['nullable', 'date', 'after_or_equal:today'],
+            'notes' => ['nullable', 'string'],
+            
+            // 選擇要安裝的訂單項目
+            'order_item_ids' => ['required', 'array', 'min:1'],
+            'order_item_ids.*' => ['required', 'integer', 'exists:order_items,id'],
+            
+            // 可選的安裝規格（按訂單項目ID）
+            'specifications' => ['nullable', 'array'],
+            'specifications.*' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * 獲取已定義驗證規則的錯誤訊息
+     */
+    public function messages(): array
+    {
+        return [
+            'order_id.required' => '訂單ID為必填項目',
+            'order_id.exists' => '指定的訂單不存在',
+            'scheduled_date.after_or_equal' => '預計安裝日期不能早於今天',
+            'order_item_ids.required' => '請選擇要安裝的訂單項目',
+            'order_item_ids.min' => '至少需要選擇一個訂單項目',
+            'order_item_ids.*.exists' => '指定的訂單項目不存在',
+        ];
+    }
+
+    /**
+     * 配置驗證器實例
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            // 檢查所有選擇的訂單項目是否屬於指定的訂單
+            if ($this->order_id && $this->order_item_ids) {
+                $validItemIds = \App\Models\OrderItem::where('order_id', $this->order_id)
+                    ->whereIn('id', $this->order_item_ids)
+                    ->pluck('id')
+                    ->toArray();
+                
+                $invalidIds = array_diff($this->order_item_ids, $validItemIds);
+                
+                if (!empty($invalidIds)) {
+                    $validator->errors()->add(
+                        'order_item_ids',
+                        '部分訂單項目不屬於指定的訂單：' . implode(', ', $invalidIds)
+                    );
+                }
+            }
+            
+            // 檢查訂單是否已經有相關的安裝單
+            if ($this->order_id) {
+                $existingInstallation = \App\Models\Installation::where('order_id', $this->order_id)
+                    ->whereNotIn('status', ['cancelled'])
+                    ->exists();
+                
+                if ($existingInstallation) {
+                    $validator->errors()->add(
+                        'order_id',
+                        '此訂單已有相關的安裝單'
+                    );
+                }
+            }
+        });
+    }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'order_id' => [
+                'description' => '訂單 ID',
+                'example' => 1,
+            ],
+            'installer_user_id' => [
+                'description' => '安裝師傅的用戶 ID（可選）',
+                'example' => 3,
+            ],
+            'installation_address' => [
+                'description' => '安裝地址（可選，如果不提供則使用訂單地址）',
+                'example' => '台北市大安區信義路四段1號',
+            ],
+            'scheduled_date' => [
+                'description' => '預計安裝日期（可選，格式：Y-m-d）',
+                'example' => '2025-06-25',
+            ],
+            'notes' => [
+                'description' => '備註（可選）',
+                'example' => '客戶希望下午安裝',
+            ],
+            'order_item_ids' => [
+                'description' => '要安裝的訂單項目 ID 陣列',
+                'example' => [1, 2, 3],
+            ],
+            'specifications' => [
+                'description' => '安裝規格（可選，按訂單項目 ID 對應）',
+                'example' => [
+                    '1' => '牆面安裝，高度 150cm',
+                    '2' => '標準地面安裝',
+                ],
+            ],
+        ];
+    }
+} 

--- a/inventory-api/app/Http/Requests/Api/CreateRefundRequest.php
+++ b/inventory-api/app/Http/Requests/Api/CreateRefundRequest.php
@@ -222,4 +222,42 @@ class CreateRefundRequest extends FormRequest
             $this->merge(['items' => $cleanedItems]);
         }
     }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'reason' => [
+                'description' => '退款原因（至少 10 個字符）',
+                'example' => '商品有瑕疵，客戶要求退貨',
+            ],
+            'notes' => [
+                'description' => '備註（可選）',
+                'example' => '客戶於 2025-06-24 來電申請退貨',
+            ],
+            'should_restock' => [
+                'description' => '是否將退貨商品加回庫存',
+                'example' => true,
+            ],
+            'items' => [
+                'description' => '退款品項陣列',
+                'example' => [
+                    [
+                        'order_item_id' => 1,
+                        'quantity' => 2,
+                    ],
+                    [
+                        'order_item_id' => 2,
+                        'quantity' => 1,
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/inventory-api/app/Http/Requests/Api/InventoryTimeSeriesRequest.php
+++ b/inventory-api/app/Http/Requests/Api/InventoryTimeSeriesRequest.php
@@ -65,4 +65,29 @@ class InventoryTimeSeriesRequest extends FormRequest
             'end_date.after_or_equal' => '結束日期不能早於開始日期',
         ];
     }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'product_variant_id' => [
+                'description' => '商品變體 ID',
+                'example' => 1,
+            ],
+            'start_date' => [
+                'description' => '開始日期（格式：Y-m-d）',
+                'example' => '2025-06-01',
+            ],
+            'end_date' => [
+                'description' => '結束日期（格式：Y-m-d）',
+                'example' => '2025-06-24',
+            ],
+        ];
+    }
 } 

--- a/inventory-api/app/Http/Requests/Api/StoreInstallationRequest.php
+++ b/inventory-api/app/Http/Requests/Api/StoreInstallationRequest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreInstallationRequest extends FormRequest
+{
+    /**
+     * 判斷用戶是否有權限發出此請求
+     */
+    public function authorize(): bool
+    {
+        return true; // 實際權限檢查在 Controller 中進行
+    }
+
+    /**
+     * 獲取適用於該請求的驗證規則
+     */
+    public function rules(): array
+    {
+        return [
+            'order_id' => ['nullable', 'integer', 'exists:orders,id'],
+            'installer_user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'customer_name' => ['required', 'string', 'max:255'],
+            'customer_phone' => ['required', 'string', 'max:20'],
+            'installation_address' => ['required', 'string'],
+            'scheduled_date' => ['nullable', 'date', 'after_or_equal:today'],
+            'notes' => ['nullable', 'string'],
+            
+            // 安裝項目
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.order_item_id' => ['nullable', 'integer', 'exists:order_items,id'],
+            'items.*.product_name' => ['required', 'string', 'max:255'],
+            'items.*.sku' => ['required', 'string', 'max:100'],
+            'items.*.quantity' => ['required', 'integer', 'min:1'],
+            'items.*.specifications' => ['nullable', 'string'],
+            'items.*.notes' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * 獲取已定義驗證規則的錯誤訊息
+     */
+    public function messages(): array
+    {
+        return [
+            'customer_name.required' => '客戶姓名為必填項目',
+            'customer_phone.required' => '客戶電話為必填項目',
+            'installation_address.required' => '安裝地址為必填項目',
+            'scheduled_date.after_or_equal' => '預計安裝日期不能早於今天',
+            'items.required' => '至少需要一個安裝項目',
+            'items.min' => '至少需要一個安裝項目',
+            'items.*.product_name.required' => '商品名稱為必填項目',
+            'items.*.sku.required' => '商品編號為必填項目',
+            'items.*.quantity.required' => '安裝數量為必填項目',
+            'items.*.quantity.min' => '安裝數量必須至少為 1',
+        ];
+    }
+
+    /**
+     * 配置驗證器實例
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            // 如果指定了 order_id，檢查安裝項目是否與訂單項目對應
+            if ($this->order_id && $this->items) {
+                foreach ($this->items as $index => $item) {
+                    if (isset($item['order_item_id'])) {
+                        // 驗證 order_item_id 是否屬於指定的訂單
+                        $belongsToOrder = \App\Models\OrderItem::where('id', $item['order_item_id'])
+                            ->where('order_id', $this->order_id)
+                            ->exists();
+                        
+                        if (!$belongsToOrder) {
+                            $validator->errors()->add(
+                                "items.{$index}.order_item_id",
+                                '指定的訂單項目不屬於該訂單'
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'order_id' => [
+                'description' => '關聯的訂單 ID（可選）',
+                'example' => 1,
+            ],
+            'installer_user_id' => [
+                'description' => '安裝師傅的用戶 ID（可選）',
+                'example' => 3,
+            ],
+            'customer_name' => [
+                'description' => '客戶姓名',
+                'example' => '王小明',
+            ],
+            'customer_phone' => [
+                'description' => '客戶電話',
+                'example' => '0912345678',
+            ],
+            'installation_address' => [
+                'description' => '安裝地址',
+                'example' => '台北市大安區信義路四段1號',
+            ],
+            'scheduled_date' => [
+                'description' => '預計安裝日期（可選，格式：Y-m-d）',
+                'example' => '2025-06-25',
+            ],
+            'notes' => [
+                'description' => '備註（可選）',
+                'example' => '客戶希望下午安裝',
+            ],
+            'items' => [
+                'description' => '安裝項目陣列',
+                'example' => [
+                    [
+                        'order_item_id' => 1,
+                        'product_name' => '層架組合',
+                        'sku' => 'SHELF-001',
+                        'quantity' => 2,
+                        'specifications' => '牆面安裝，高度 150cm',
+                        'notes' => '需要特殊固定器',
+                    ],
+                ],
+            ],
+        ];
+    }
+} 

--- a/inventory-api/app/Http/Requests/Api/UpdateCustomerRequest.php
+++ b/inventory-api/app/Http/Requests/Api/UpdateCustomerRequest.php
@@ -25,7 +25,8 @@ class UpdateCustomerRequest extends FormRequest
     public function rules(): array
     {
         // 獲取路由中正在更新的 customer ID
-        $customerId = $this->route('customer')->id;
+        $customer = $this->route('customer');
+        $customerId = $customer ? $customer->id : null;
 
         return [
             // 客戶基本資訊驗證
@@ -109,6 +110,57 @@ class UpdateCustomerRequest extends FormRequest
             'addresses.*.address.max' => '地址不能超過 255 個字元',
             'addresses.*.is_default.required' => '請指定是否為預設地址',
             'addresses.*.is_default.boolean' => '預設地址設定格式錯誤',
+        ];
+    }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'name' => [
+                'description' => '客戶名稱或公司抬頭',
+                'example' => '測試客戶（已更新）',
+            ],
+            'phone' => [
+                'description' => '手機號碼',
+                'example' => '0987654321',
+            ],
+            'is_company' => [
+                'description' => '是否為公司戶',
+                'example' => false,
+            ],
+            'tax_id' => [
+                'description' => '統一編號（is_company 為 true 時必填）',
+                'example' => '12345678',
+            ],
+            'industry_type' => [
+                'description' => '行業別',
+                'example' => '設計師',
+            ],
+            'payment_type' => [
+                'description' => '付款類別',
+                'example' => '現金付款',
+            ],
+            'contact_address' => [
+                'description' => '主要聯絡地址',
+                'example' => '台北市信義區',
+            ],
+            'addresses' => [
+                'description' => '運送地址列表',
+                'example' => [
+                    [
+                        'id' => 1,
+                        'address' => '台北市大安區',
+                        'is_default' => true,
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/inventory-api/app/Http/Requests/Api/UpdateInstallationRequest.php
+++ b/inventory-api/app/Http/Requests/Api/UpdateInstallationRequest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateInstallationRequest extends FormRequest
+{
+    /**
+     * 判斷用戶是否有權限發出此請求
+     */
+    public function authorize(): bool
+    {
+        return true; // 實際權限檢查在 Controller 中進行
+    }
+
+    /**
+     * 獲取適用於該請求的驗證規則
+     */
+    public function rules(): array
+    {
+        $installation = $this->route('installation');
+        
+        return [
+            'installer_user_id' => ['nullable', 'integer', 'exists:users,id'],
+            'customer_name' => ['sometimes', 'required', 'string', 'max:255'],
+            'customer_phone' => ['sometimes', 'required', 'string', 'max:20'],
+            'installation_address' => ['sometimes', 'required', 'string'],
+            'status' => [
+                'sometimes',
+                'required',
+                Rule::in(['pending', 'scheduled', 'in_progress', 'completed', 'cancelled'])
+            ],
+            'scheduled_date' => ['nullable', 'date', 'after_or_equal:today'],
+            'actual_start_time' => ['nullable', 'date_format:Y-m-d H:i:s'],
+            'actual_end_time' => [
+                'nullable',
+                'date_format:Y-m-d H:i:s',
+                'after:actual_start_time'
+            ],
+            'notes' => ['nullable', 'string'],
+            
+            // 安裝項目（僅當提供時才驗證）
+            'items' => ['sometimes', 'array'],
+            'items.*.id' => ['nullable', 'integer', 'exists:installation_items,id'],
+            'items.*.product_name' => ['required', 'string', 'max:255'],
+            'items.*.sku' => ['required', 'string', 'max:100'],
+            'items.*.quantity' => ['required', 'integer', 'min:1'],
+            'items.*.specifications' => ['nullable', 'string'],
+            'items.*.status' => ['sometimes', 'required', Rule::in(['pending', 'completed'])],
+            'items.*.notes' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * 獲取已定義驗證規則的錯誤訊息
+     */
+    public function messages(): array
+    {
+        return [
+            'customer_name.required' => '客戶姓名為必填項目',
+            'customer_phone.required' => '客戶電話為必填項目',
+            'installation_address.required' => '安裝地址為必填項目',
+            'status.in' => '無效的安裝狀態',
+            'scheduled_date.after_or_equal' => '預計安裝日期不能早於今天',
+            'actual_start_time.date_format' => '開始時間格式不正確',
+            'actual_end_time.date_format' => '結束時間格式不正確',
+            'actual_end_time.after' => '結束時間必須晚於開始時間',
+            'items.*.product_name.required' => '商品名稱為必填項目',
+            'items.*.sku.required' => '商品編號為必填項目',
+            'items.*.quantity.required' => '安裝數量為必填項目',
+            'items.*.quantity.min' => '安裝數量必須至少為 1',
+            'items.*.status.in' => '無效的項目狀態',
+        ];
+    }
+
+    /**
+     * 配置驗證器實例
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            $installation = $this->route('installation');
+            
+            // 檢查狀態轉換的合法性
+            if ($this->has('status')) {
+                $currentStatus = $installation->status;
+                $newStatus = $this->status;
+                
+                // 定義允許的狀態轉換
+                $allowedTransitions = [
+                    'pending' => ['scheduled', 'cancelled'],
+                    'scheduled' => ['in_progress', 'cancelled'],
+                    'in_progress' => ['completed', 'cancelled'],
+                    'completed' => [], // 已完成不能轉換
+                    'cancelled' => [], // 已取消不能轉換
+                ];
+                
+                if (!in_array($newStatus, $allowedTransitions[$currentStatus] ?? [])) {
+                    $validator->errors()->add('status', "無法從 {$currentStatus} 狀態轉換到 {$newStatus} 狀態");
+                }
+            }
+            
+            // 如果要更新為進行中，必須有開始時間
+            if ($this->status === 'in_progress' && !$this->actual_start_time && !$installation->actual_start_time) {
+                $validator->errors()->add('actual_start_time', '進行中狀態必須設定開始時間');
+            }
+            
+            // 如果要更新為已完成，必須有結束時間
+            if ($this->status === 'completed' && !$this->actual_end_time && !$installation->actual_end_time) {
+                $validator->errors()->add('actual_end_time', '已完成狀態必須設定結束時間');
+            }
+        });
+    }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'installer_user_id' => [
+                'description' => '安裝師傅的用戶 ID（可選）',
+                'example' => 3,
+            ],
+            'customer_name' => [
+                'description' => '客戶姓名',
+                'example' => '王小明',
+            ],
+            'customer_phone' => [
+                'description' => '客戶電話',
+                'example' => '0912345678',
+            ],
+            'installation_address' => [
+                'description' => '安裝地址',
+                'example' => '台北市大安區信義路四段1號',
+            ],
+            'status' => [
+                'description' => '安裝狀態（pending: 待處理, scheduled: 已排程, in_progress: 進行中, completed: 已完成, cancelled: 已取消）',
+                'example' => 'scheduled',
+            ],
+            'scheduled_date' => [
+                'description' => '預計安裝日期（可選，格式：Y-m-d）',
+                'example' => '2025-06-25',
+            ],
+            'actual_start_time' => [
+                'description' => '實際開始時間（可選，格式：Y-m-d H:i:s）',
+                'example' => '2025-06-25 09:00:00',
+            ],
+            'actual_end_time' => [
+                'description' => '實際結束時間（可選，格式：Y-m-d H:i:s）',
+                'example' => '2025-06-25 12:00:00',
+            ],
+            'notes' => [
+                'description' => '備註（可選）',
+                'example' => '安裝順利完成',
+            ],
+            'items' => [
+                'description' => '安裝項目陣列（可選）',
+                'example' => [
+                    [
+                        'id' => 1,
+                        'product_name' => '層架組合',
+                        'sku' => 'SHELF-001',
+                        'quantity' => 2,
+                        'specifications' => '牆面安裝，高度 150cm',
+                        'status' => 'completed',
+                        'notes' => '已安裝完成',
+                    ],
+                ],
+            ],
+        ];
+    }
+} 

--- a/inventory-api/app/Http/Requests/Api/UpdateOrderItemStatusRequest.php
+++ b/inventory-api/app/Http/Requests/Api/UpdateOrderItemStatusRequest.php
@@ -56,4 +56,25 @@ class UpdateOrderItemStatusRequest extends FormRequest
             'notes.max' => '備註不能超過 500 個字符',
         ];
     }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'status' => [
+                'description' => '項目狀態（待處理、已叫貨、已出貨、完成）',
+                'example' => '已叫貨',
+            ],
+            'notes' => [
+                'description' => '備註（可選）',
+                'example' => '已向供應商下單',
+            ],
+        ];
+    }
 }

--- a/inventory-api/app/Http/Requests/Api/UpdateOrderRequest.php
+++ b/inventory-api/app/Http/Requests/Api/UpdateOrderRequest.php
@@ -76,4 +76,85 @@ class UpdateOrderRequest extends FormRequest
             'items.*.status.in' => '訂單項目狀態必須是：pending、confirmed、processing、completed 或 cancelled',
         ];
     }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'customer_id' => [
+                'description' => '客戶 ID',
+                'example' => 1,
+            ],
+            'shipping_status' => [
+                'description' => '運送狀態（pending: 待處理, processing: 處理中, shipped: 已出貨, delivered: 已送達）',
+                'example' => 'pending',
+            ],
+            'payment_status' => [
+                'description' => '付款狀態（pending: 待付款, paid: 已付款, failed: 付款失敗, refunded: 已退款）',
+                'example' => 'pending',
+            ],
+            'shipping_fee' => [
+                'description' => '運費',
+                'example' => 100,
+            ],
+            'tax' => [
+                'description' => '稅額',
+                'example' => 500,
+            ],
+            'discount_amount' => [
+                'description' => '折扣金額',
+                'example' => 200,
+            ],
+            'payment_method' => [
+                'description' => '付款方式',
+                'example' => '現金',
+            ],
+            'shipping_address' => [
+                'description' => '運送地址',
+                'example' => '台北市信義區信義路五段7號',
+            ],
+            'billing_address' => [
+                'description' => '帳單地址',
+                'example' => '台北市信義區信義路五段7號',
+            ],
+            'customer_address_id' => [
+                'description' => '客戶地址 ID',
+                'example' => 1,
+            ],
+            'notes' => [
+                'description' => '訂單備註',
+                'example' => '請小心處理',
+            ],
+            'po_number' => [
+                'description' => '採購單號',
+                'example' => 'PO-2025-001',
+            ],
+            'reference_number' => [
+                'description' => '參考編號',
+                'example' => 'REF-2025-001',
+            ],
+            'items' => [
+                'description' => '訂單項目陣列',
+                'example' => [
+                    [
+                        'id' => 1,
+                        'product_variant_id' => 1,
+                        'is_stocked_sale' => true,
+                        'status' => 'pending',
+                        'quantity' => 2,
+                        'price' => 1000,
+                        'cost' => 800,
+                        'tax_rate' => 5,
+                        'discount_amount' => 100,
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/inventory-api/app/Http/Requests/Api/UploadProductImageRequest.php
+++ b/inventory-api/app/Http/Requests/Api/UploadProductImageRequest.php
@@ -189,4 +189,21 @@ class UploadProductImageRequest extends FormRequest
             ]);
         }
     }
+    
+    /**
+     * 取得請求體參數的文檔
+     * 
+     * 用於 Scribe API 文檔生成
+     * 
+     * @return array
+     */
+    public function bodyParameters(): array
+    {
+        return [
+            'image' => [
+                'description' => '要上傳的圖片檔案（支援 JPEG、JPG、PNG、GIF、WebP 格式，最大 5MB）',
+                'example' => 'no-example',
+            ],
+        ];
+    }
 } 

--- a/inventory-api/app/Http/Resources/Api/InstallationItemResource.php
+++ b/inventory-api/app/Http/Resources/Api/InstallationItemResource.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InstallationItemResource extends JsonResource
+{
+    /**
+     * 將資源轉換為陣列
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'installation_id' => $this->installation_id,
+            'order_item_id' => $this->order_item_id,
+            
+            // 商品資訊
+            'product_name' => $this->product_name,
+            'sku' => $this->sku,
+            'quantity' => $this->quantity,
+            'specifications' => $this->specifications,
+            
+            // 狀態
+            'status' => $this->status,
+            
+            // 備註
+            'notes' => $this->notes,
+            
+            // 時間戳記
+            'created_at' => $this->created_at->format('Y-m-d H:i:s'),
+            'updated_at' => $this->updated_at->format('Y-m-d H:i:s'),
+            
+            // 關聯資源（按需加載）
+            'order_item' => new OrderItemResource($this->whenLoaded('orderItem')),
+            
+            // 計算屬性
+            'is_completed' => $this->isCompleted(),
+            'is_pending' => $this->isPending(),
+        ];
+    }
+} 

--- a/inventory-api/app/Http/Resources/Api/InstallationResource.php
+++ b/inventory-api/app/Http/Resources/Api/InstallationResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class InstallationResource extends JsonResource
+{
+    /**
+     * 將資源轉換為陣列
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'installation_number' => $this->installation_number,
+            'order_id' => $this->order_id,
+            'installer_user_id' => $this->installer_user_id,
+            'created_by' => $this->created_by,
+            
+            // 客戶資訊
+            'customer_name' => $this->customer_name,
+            'customer_phone' => $this->customer_phone,
+            'installation_address' => $this->installation_address,
+            
+            // 狀態和時間
+            'status' => $this->status,
+            'scheduled_date' => $this->scheduled_date?->format('Y-m-d'),
+            'actual_start_time' => $this->actual_start_time?->format('Y-m-d H:i:s'),
+            'actual_end_time' => $this->actual_end_time?->format('Y-m-d H:i:s'),
+            
+            // 備註
+            'notes' => $this->notes,
+            
+            // 時間戳記
+            'created_at' => $this->created_at->format('Y-m-d H:i:s'),
+            'updated_at' => $this->updated_at->format('Y-m-d H:i:s'),
+            
+            // 關聯資源（按需加載）
+            'items' => InstallationItemResource::collection($this->whenLoaded('items')),
+            'order' => new OrderResource($this->whenLoaded('order')),
+            'installer' => new UserResource($this->whenLoaded('installer')),
+            'creator' => new UserResource($this->whenLoaded('creator')),
+            
+            // 計算屬性
+            'pending_items_count' => $this->when(
+                $this->relationLoaded('items'),
+                fn() => $this->pending_items_count
+            ),
+            'total_items_count' => $this->when(
+                $this->relationLoaded('items'),
+                fn() => $this->items->count()
+            ),
+            'is_completed' => $this->isCompleted(),
+            'can_be_cancelled' => $this->canBeCancelled(),
+            'has_started' => $this->hasStarted(),
+        ];
+    }
+} 

--- a/inventory-api/app/Models/Installation.php
+++ b/inventory-api/app/Models/Installation.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Installation extends Model
+{
+    /**
+     * 可批量賦值的屬性
+     */
+    protected $fillable = [
+        'installation_number',
+        'order_id',
+        'installer_user_id',
+        'created_by',
+        'customer_name',
+        'customer_phone',
+        'installation_address',
+        'status',
+        'scheduled_date',
+        'actual_start_time',
+        'actual_end_time',
+        'notes',
+    ];
+
+    /**
+     * 屬性轉換
+     */
+    protected $casts = [
+        'scheduled_date' => 'date',
+        'actual_start_time' => 'datetime',
+        'actual_end_time' => 'datetime',
+    ];
+
+    /**
+     * 一個安裝單包含多個安裝項目 (One-to-Many)
+     */
+    public function items(): HasMany
+    {
+        return $this->hasMany(InstallationItem::class);
+    }
+
+    /**
+     * 一個安裝單包含多個安裝項目 (別名方法)
+     */
+    public function installationItems(): HasMany
+    {
+        return $this->hasMany(InstallationItem::class);
+    }
+
+    /**
+     * 一個安裝單可能關聯一個訂單 (Many-to-One / Inverse)
+     * 可選關聯，實現鬆耦合
+     */
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    /**
+     * 一個安裝單由一個安裝師傅負責 (Many-to-One / Inverse)
+     */
+    public function installer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'installer_user_id');
+    }
+
+    /**
+     * 一個安裝單由一個用戶創建 (Many-to-One / Inverse)
+     */
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * 🎯 判斷安裝單是否已完成
+     * 
+     * @return bool
+     */
+    public function isCompleted(): bool
+    {
+        return $this->status === 'completed';
+    }
+
+    /**
+     * 🎯 判斷安裝單是否可以取消
+     * 
+     * @return bool
+     */
+    public function canBeCancelled(): bool
+    {
+        return in_array($this->status, ['pending', 'scheduled']);
+    }
+
+    /**
+     * 🎯 判斷安裝單是否已開始
+     * 
+     * @return bool
+     */
+    public function hasStarted(): bool
+    {
+        return in_array($this->status, ['in_progress', 'completed']);
+    }
+
+    /**
+     * 🎯 獲取所有待完成的安裝項目數量
+     * 
+     * @return int
+     */
+    public function getPendingItemsCountAttribute(): int
+    {
+        // 如果 items 關聯已加載，則在集合上操作以避免額外查詢
+        if ($this->relationLoaded('items')) {
+            return $this->items->where('status', 'pending')->count();
+        }
+        // 否則，進行資料庫查詢
+        return $this->items()->where('status', 'pending')->count();
+    }
+
+    /**
+     * 🎯 判斷所有安裝項目是否都已完成
+     * 
+     * @return bool
+     */
+    public function areAllItemsCompleted(): bool
+    {
+        return $this->getPendingItemsCountAttribute() === 0;
+    }
+} 

--- a/inventory-api/app/Models/InstallationItem.php
+++ b/inventory-api/app/Models/InstallationItem.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InstallationItem extends Model
+{
+    /**
+     * 可批量賦值的屬性
+     */
+    protected $fillable = [
+        'installation_id',
+        'order_item_id',
+        'product_name',
+        'sku',
+        'quantity',
+        'specifications',
+        'status',
+        'notes',
+    ];
+
+    /**
+     * 屬性轉換
+     */
+    protected $casts = [
+        'quantity' => 'integer',
+    ];
+
+    /**
+     * 一個安裝項目屬於一個安裝單 (Many-to-One / Inverse)
+     */
+    public function installation(): BelongsTo
+    {
+        return $this->belongsTo(Installation::class);
+    }
+
+    /**
+     * 一個安裝項目可能關聯一個訂單項目 (Many-to-One / Inverse)
+     * 可選關聯，實現鬆耦合
+     */
+    public function orderItem(): BelongsTo
+    {
+        return $this->belongsTo(OrderItem::class);
+    }
+
+    /**
+     * 🎯 判斷安裝項目是否已完成
+     * 
+     * @return bool
+     */
+    public function isCompleted(): bool
+    {
+        return $this->status === 'completed';
+    }
+
+    /**
+     * 🎯 判斷安裝項目是否待處理
+     * 
+     * @return bool
+     */
+    public function isPending(): bool
+    {
+        return $this->status === 'pending';
+    }
+
+    /**
+     * 🎯 標記為已完成
+     * 
+     * @return bool
+     */
+    public function markAsCompleted(): bool
+    {
+        return $this->update(['status' => 'completed']);
+    }
+
+    /**
+     * 🎯 標記為待處理
+     * 
+     * @return bool
+     */
+    public function markAsPending(): bool
+    {
+        return $this->update(['status' => 'pending']);
+    }
+} 

--- a/inventory-api/app/Models/Order.php
+++ b/inventory-api/app/Models/Order.php
@@ -91,6 +91,14 @@ class Order extends Model
     }
 
     /**
+     * 一個訂單可能有多個相關的安裝單 (One-to-Many)
+     */
+    public function installations(): HasMany
+    {
+        return $this->hasMany(Installation::class);
+    }
+
+    /**
      * 🎯 判斷訂單是否包含訂製商品
      * 
      * @return bool

--- a/inventory-api/app/Models/User.php
+++ b/inventory-api/app/Models/User.php
@@ -16,6 +16,7 @@ class User extends Authenticatable
     public const ROLE_ADMIN = 'admin';
     public const ROLE_STAFF = 'staff';
     public const ROLE_VIEWER = 'viewer';
+    public const ROLE_INSTALLER = 'installer';
 
     /**
      * The attributes that are mass assignable.
@@ -100,6 +101,17 @@ class User extends Authenticatable
     }
 
     /**
+     * 檢查用戶是否具有任何指定的角色
+     *
+     * @param array $roles
+     * @return bool
+     */
+    public function hasAnyRole(array $roles): bool
+    {
+        return in_array($this->role, $roles);
+    }
+
+    /**
      * 獲取所有可用的角色
      *
      * @return array
@@ -110,6 +122,7 @@ class User extends Authenticatable
             self::ROLE_ADMIN => '管理員',
             self::ROLE_STAFF => '員工',
             self::ROLE_VIEWER => '檢視者',
+            self::ROLE_INSTALLER => '安裝師傅',
         ];
     }
 }

--- a/inventory-api/app/Policies/InstallationPolicy.php
+++ b/inventory-api/app/Policies/InstallationPolicy.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Installation;
+use App\Models\User;
+
+class InstallationPolicy
+{
+    /**
+     * 判斷用戶是否可以查看任何安裝單列表
+     */
+    public function viewAny(User $user): bool
+    {
+        // admin: 可以查看所有安裝單
+        // installer: 可以查看分配給自己的安裝單
+        // staff: 可以查看所有安裝單
+        // viewer: 可以查看所有安裝單
+        return $user->hasAnyRole(['admin', 'staff', 'viewer', 'installer']);
+    }
+
+    /**
+     * 判斷用戶是否可以查看特定安裝單
+     */
+    public function view(User $user, Installation $installation): bool
+    {
+        // admin, staff, viewer 可以查看所有安裝單
+        if ($user->hasAnyRole(['admin', 'staff', 'viewer'])) {
+            return true;
+        }
+
+        // installer 只能查看分配給自己的安裝單
+        if ($user->hasRole('installer')) {
+            return $installation->installer_user_id === $user->id;
+        }
+
+        return false;
+    }
+
+    /**
+     * 判斷用戶是否可以創建安裝單
+     */
+    public function create(User $user): bool
+    {
+        // 只有 admin 和 staff 可以創建安裝單
+        return $user->hasAnyRole(['admin', 'staff']);
+    }
+
+    /**
+     * 判斷用戶是否可以更新安裝單
+     */
+    public function update(User $user, Installation $installation): bool
+    {
+        // admin 可以更新所有安裝單
+        if ($user->hasRole('admin')) {
+            return true;
+        }
+
+        // staff 可以更新所有安裝單
+        if ($user->hasRole('staff')) {
+            return true;
+        }
+
+        // installer 可以更新分配給自己的安裝單（僅限狀態和時間）
+        if ($user->hasRole('installer') && $installation->installer_user_id === $user->id) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * 判斷用戶是否可以刪除安裝單
+     */
+    public function delete(User $user, Installation $installation): bool
+    {
+        // 只有 admin 可以刪除安裝單
+        // 且只能刪除狀態為 pending 或 cancelled 的安裝單
+        return $user->hasRole('admin') && in_array($installation->status, ['pending', 'cancelled']);
+    }
+
+    /**
+     * 判斷用戶是否可以分配安裝師傅
+     */
+    public function assignInstaller(User $user, Installation $installation): bool
+    {
+        // 只有 admin 和 staff 可以分配安裝師傅
+        return $user->hasAnyRole(['admin', 'staff']);
+    }
+
+    /**
+     * 判斷用戶是否可以更新安裝狀態
+     */
+    public function updateStatus(User $user, Installation $installation): bool
+    {
+        // admin 和 staff 可以更新任何安裝單的狀態
+        if ($user->hasAnyRole(['admin', 'staff'])) {
+            return true;
+        }
+
+        // installer 可以更新分配給自己的安裝單狀態
+        if ($user->hasRole('installer') && $installation->installer_user_id === $user->id) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * 判斷用戶是否可以從訂單創建安裝單
+     */
+    public function createFromOrder(User $user): bool
+    {
+        // 只有 admin 和 staff 可以從訂單創建安裝單
+        return $user->hasAnyRole(['admin', 'staff']);
+    }
+
+    /**
+     * 判斷用戶是否可以取消安裝單
+     */
+    public function cancel(User $user, Installation $installation): bool
+    {
+        // 只有 admin 和 staff 可以取消安裝單
+        // 且只能取消狀態為 pending 或 scheduled 的安裝單
+        return $user->hasAnyRole(['admin', 'staff']) && $installation->canBeCancelled();
+    }
+} 

--- a/inventory-api/app/Providers/AuthServiceProvider.php
+++ b/inventory-api/app/Providers/AuthServiceProvider.php
@@ -6,6 +6,7 @@ use App\Models\Attribute;
 use App\Models\AttributeValue;
 use App\Models\Category;
 use App\Models\Customer;
+use App\Models\Installation;
 use App\Models\InventoryTransfer;
 use App\Models\Order;
 use App\Models\Product;
@@ -16,6 +17,7 @@ use App\Policies\AttributePolicy;
 use App\Policies\AttributeValuePolicy;
 use App\Policies\CategoryPolicy;
 use App\Policies\CustomerPolicy;
+use App\Policies\InstallationPolicy;
 use App\Policies\InventoryTransferPolicy;
 use App\Policies\OrderPolicy;
 use App\Policies\ProductPolicy;
@@ -50,6 +52,7 @@ class AuthServiceProvider extends ServiceProvider
         Store::class => StorePolicy::class,
         Purchase::class => PurchasePolicy::class,
         Order::class => OrderPolicy::class,
+        Installation::class => InstallationPolicy::class,
     ];
 
     /**

--- a/inventory-api/app/Services/InstallationNumberGenerator.php
+++ b/inventory-api/app/Services/InstallationNumberGenerator.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+/**
+ * 安裝單編號生成器服務
+ * 
+ * 負責生成唯一的安裝單編號，格式為 I-YYYYMM-XXXX
+ * 使用資料庫事務和行鎖確保並發安全
+ */
+class InstallationNumberGenerator
+{
+    /**
+     * 生成下一個安裝單編號
+     * 
+     * @return string 格式化的安裝單編號 (例如: I-202506-0001)
+     * @throws \Exception 當生成失敗時
+     */
+    public function generateNextNumber(): string
+    {
+        return DB::transaction(function () {
+            // 獲取當前年月
+            $yearMonth = Carbon::now()->format('Y-m'); // 例如: 2025-06
+            
+            // 查詢並鎖定該月的計數器記錄
+            $counter = DB::table('monthly_installation_counters')
+                ->where('year_month', $yearMonth)
+                ->lockForUpdate()
+                ->first();
+            
+            if (!$counter) {
+                // 如果記錄不存在，創建新記錄
+                DB::table('monthly_installation_counters')->insert([
+                    'year_month' => $yearMonth,
+                    'last_sequence' => 1,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+                
+                $newSequence = 1;
+            } else {
+                // 如果記錄存在，遞增序號
+                $newSequence = $counter->last_sequence + 1;
+                
+                DB::table('monthly_installation_counters')
+                    ->where('year_month', $yearMonth)
+                    ->update([
+                        'last_sequence' => $newSequence,
+                        'updated_at' => now(),
+                    ]);
+            }
+            
+            // 格式化安裝單編號
+            // 添加 I- 前綴以區分安裝單，移除年月中的連字符，並格式化序號為4位數
+            $installationNumber = sprintf('I-%s-%04d', str_replace('-', '', $yearMonth), $newSequence);
+            
+            return $installationNumber;
+        });
+    }
+    
+    /**
+     * 獲取指定年月的當前序號（不遞增）
+     * 
+     * @param string|null $yearMonth 年月格式 (YYYY-MM)，預設為當前年月
+     * @return int 當前序號，如果不存在則返回0
+     */
+    public function getCurrentSequence(?string $yearMonth = null): int
+    {
+        $yearMonth = $yearMonth ?? Carbon::now()->format('Y-m');
+        
+        $counter = DB::table('monthly_installation_counters')
+            ->where('year_month', $yearMonth)
+            ->first();
+        
+        return $counter ? $counter->last_sequence : 0;
+    }
+    
+    /**
+     * 重置指定年月的序號計數器（僅供測試或特殊情況使用）
+     * 
+     * @param string $yearMonth 年月格式 (YYYY-MM)
+     * @param int $sequence 要設置的序號
+     * @return void
+     */
+    public function resetSequence(string $yearMonth, int $sequence = 0): void
+    {
+        DB::table('monthly_installation_counters')->updateOrInsert(
+            ['year_month' => $yearMonth],
+            [
+                'last_sequence' => $sequence,
+                'updated_at' => now(),
+            ]
+        );
+    }
+} 

--- a/inventory-api/app/Services/InstallationService.php
+++ b/inventory-api/app/Services/InstallationService.php
@@ -1,0 +1,294 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Installation;
+use App\Models\InstallationItem;
+use App\Models\Order;
+use App\Models\OrderItem;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Collection;
+
+/**
+ * 安裝管理服務
+ * 
+ * 負責處理安裝單的創建、更新、狀態管理等業務邏輯
+ */
+class InstallationService
+{
+    /**
+     * @var InstallationNumberGenerator
+     */
+    private InstallationNumberGenerator $numberGenerator;
+
+    /**
+     * 建構子
+     */
+    public function __construct(InstallationNumberGenerator $numberGenerator)
+    {
+        $this->numberGenerator = $numberGenerator;
+    }
+
+    /**
+     * 建立新的安裝單
+     * 
+     * @param array $data 安裝單資料
+     * @param int $creatorId 建立者ID
+     * @return Installation
+     * @throws \Exception
+     */
+    public function createInstallation(array $data, int $creatorId): Installation
+    {
+        return DB::transaction(function () use ($data, $creatorId) {
+            // 生成安裝單號
+            $installationNumber = $this->numberGenerator->generateNextNumber();
+
+            // 建立安裝單主檔
+            $installation = Installation::create([
+                'installation_number' => $installationNumber,
+                'order_id' => $data['order_id'] ?? null,
+                'installer_user_id' => $data['installer_user_id'] ?? null,
+                'created_by' => $creatorId,
+                'customer_name' => $data['customer_name'],
+                'customer_phone' => $data['customer_phone'],
+                'installation_address' => $data['installation_address'],
+                'status' => 'pending',
+                'scheduled_date' => $data['scheduled_date'] ?? null,
+                'notes' => $data['notes'] ?? null,
+            ]);
+
+            // 建立安裝項目
+            foreach ($data['items'] as $item) {
+                InstallationItem::create([
+                    'installation_id' => $installation->id,
+                    'order_item_id' => $item['order_item_id'] ?? null,
+                    'product_name' => $item['product_name'],
+                    'sku' => $item['sku'],
+                    'quantity' => $item['quantity'],
+                    'specifications' => $item['specifications'] ?? null,
+                    'status' => 'pending',
+                    'notes' => $item['notes'] ?? null,
+                ]);
+            }
+
+            return $installation->fresh(['items']);
+        });
+    }
+
+    /**
+     * 從訂單建立安裝單
+     * 
+     * @param int $orderId 訂單ID
+     * @param array $itemIds 要安裝的訂單項目ID
+     * @param array $additionalData 額外資料
+     * @param int $creatorId 建立者ID
+     * @return Installation
+     * @throws \Exception
+     */
+    public function createFromOrder(int $orderId, array $itemIds, array $additionalData, int $creatorId): Installation
+    {
+        return DB::transaction(function () use ($orderId, $itemIds, $additionalData, $creatorId) {
+            // 取得訂單資料
+            $order = Order::with(['customer', 'items' => function ($query) use ($itemIds) {
+                $query->whereIn('id', $itemIds);
+            }])->findOrFail($orderId);
+
+            // 準備安裝單資料
+            $installationData = [
+                'order_id' => $orderId,
+                'installer_user_id' => $additionalData['installer_user_id'] ?? null,
+                'customer_name' => $order->customer->name,
+                'customer_phone' => $order->customer->phone,
+                'installation_address' => $additionalData['installation_address'] ?? $order->shipping_address,
+                'scheduled_date' => $additionalData['scheduled_date'] ?? null,
+                'notes' => $additionalData['notes'] ?? null,
+                'items' => []
+            ];
+
+            // 轉換訂單項目為安裝項目
+            foreach ($order->items as $orderItem) {
+                $installationData['items'][] = [
+                    'order_item_id' => $orderItem->id,
+                    'product_name' => $orderItem->product_name,
+                    'sku' => $orderItem->sku,
+                    'quantity' => $orderItem->quantity,
+                    'specifications' => $additionalData['specifications'][$orderItem->id] ?? null,
+                ];
+            }
+
+            return $this->createInstallation($installationData, $creatorId);
+        });
+    }
+
+    /**
+     * 更新安裝單
+     * 
+     * @param Installation $installation
+     * @param array $data
+     * @return Installation
+     * @throws \Exception
+     */
+    public function updateInstallation(Installation $installation, array $data): Installation
+    {
+        return DB::transaction(function () use ($installation, $data) {
+            // 更新安裝單主檔
+            $installation->update(array_filter([
+                'installer_user_id' => $data['installer_user_id'] ?? $installation->installer_user_id,
+                'customer_name' => $data['customer_name'] ?? $installation->customer_name,
+                'customer_phone' => $data['customer_phone'] ?? $installation->customer_phone,
+                'installation_address' => $data['installation_address'] ?? $installation->installation_address,
+                'status' => $data['status'] ?? $installation->status,
+                'scheduled_date' => array_key_exists('scheduled_date', $data) ? $data['scheduled_date'] : $installation->scheduled_date,
+                'actual_start_time' => array_key_exists('actual_start_time', $data) ? $data['actual_start_time'] : $installation->actual_start_time,
+                'actual_end_time' => array_key_exists('actual_end_time', $data) ? $data['actual_end_time'] : $installation->actual_end_time,
+                'notes' => array_key_exists('notes', $data) ? $data['notes'] : $installation->notes,
+            ], fn($value) => !is_null($value)));
+
+            // 更新安裝項目（如果有提供）
+            if (isset($data['items'])) {
+                $existingItemIds = [];
+                
+                foreach ($data['items'] as $itemData) {
+                    if (isset($itemData['id'])) {
+                        // 更新現有項目
+                        $item = InstallationItem::findOrFail($itemData['id']);
+                        $item->update(array_filter([
+                            'product_name' => $itemData['product_name'] ?? $item->product_name,
+                            'sku' => $itemData['sku'] ?? $item->sku,
+                            'quantity' => $itemData['quantity'] ?? $item->quantity,
+                            'specifications' => array_key_exists('specifications', $itemData) ? $itemData['specifications'] : $item->specifications,
+                            'status' => $itemData['status'] ?? $item->status,
+                            'notes' => array_key_exists('notes', $itemData) ? $itemData['notes'] : $item->notes,
+                        ], fn($value) => !is_null($value)));
+                        
+                        $existingItemIds[] = $item->id;
+                    } else {
+                        // 新增項目
+                        $newItem = InstallationItem::create([
+                            'installation_id' => $installation->id,
+                            'order_item_id' => $itemData['order_item_id'] ?? null,
+                            'product_name' => $itemData['product_name'],
+                            'sku' => $itemData['sku'],
+                            'quantity' => $itemData['quantity'],
+                            'specifications' => $itemData['specifications'] ?? null,
+                            'status' => $itemData['status'] ?? 'pending',
+                            'notes' => $itemData['notes'] ?? null,
+                        ]);
+                        
+                        $existingItemIds[] = $newItem->id;
+                    }
+                }
+                
+                // 刪除未包含在更新中的項目
+                $installation->items()->whereNotIn('id', $existingItemIds)->delete();
+            }
+
+            return $installation->fresh(['items']);
+        });
+    }
+
+    /**
+     * 更新安裝單狀態
+     * 
+     * @param Installation $installation
+     * @param string $newStatus
+     * @param array $additionalData
+     * @return Installation
+     */
+    public function updateStatus(Installation $installation, string $newStatus, array $additionalData = []): Installation
+    {
+        $updateData = ['status' => $newStatus];
+
+        // 根據狀態自動設定時間
+        if ($newStatus === 'in_progress' && !$installation->actual_start_time) {
+            $updateData['actual_start_time'] = now();
+        }
+
+        if ($newStatus === 'completed' && !$installation->actual_end_time) {
+            $updateData['actual_end_time'] = now();
+        }
+
+        // 合併額外資料
+        $updateData = array_merge($updateData, $additionalData);
+
+        return $this->updateInstallation($installation, $updateData);
+    }
+
+    /**
+     * 取消安裝單
+     * 
+     * @param Installation $installation
+     * @param string|null $reason
+     * @return Installation
+     * @throws \Exception
+     */
+    public function cancelInstallation(Installation $installation, ?string $reason = null): Installation
+    {
+        if (!$installation->canBeCancelled()) {
+            throw new \Exception("無法取消狀態為 {$installation->status} 的安裝單");
+        }
+
+        $updateData = ['status' => 'cancelled'];
+        
+        if ($reason) {
+            $currentNotes = $installation->notes ?? '';
+            $updateData['notes'] = $currentNotes . "\n取消原因：" . $reason;
+        }
+
+        return $this->updateInstallation($installation, $updateData);
+    }
+
+    /**
+     * 分配安裝師傅
+     * 
+     * @param Installation $installation
+     * @param int $installerUserId
+     * @return Installation
+     */
+    public function assignInstaller(Installation $installation, int $installerUserId): Installation
+    {
+        return $this->updateInstallation($installation, [
+            'installer_user_id' => $installerUserId,
+            'status' => $installation->status === 'pending' ? 'scheduled' : $installation->status,
+        ]);
+    }
+
+    /**
+     * 更新安裝項目狀態
+     * 
+     * @param InstallationItem $item
+     * @param string $status
+     * @return InstallationItem
+     */
+    public function updateItemStatus(InstallationItem $item, string $status): InstallationItem
+    {
+        $item->update(['status' => $status]);
+
+        // 檢查是否所有項目都已完成
+        $installation = $item->installation;
+        if ($status === 'completed' && $installation->areAllItemsCompleted()) {
+            // 自動更新安裝單狀態為已完成
+            $this->updateStatus($installation, 'completed');
+        }
+
+        return $item;
+    }
+
+    /**
+     * 取得安裝師傅的行程
+     * 
+     * @param int $installerUserId
+     * @param \DateTime $startDate
+     * @param \DateTime $endDate
+     * @return Collection
+     */
+    public function getInstallerSchedule(int $installerUserId, \DateTime $startDate, \DateTime $endDate): Collection
+    {
+        return Installation::where('installer_user_id', $installerUserId)
+            ->whereBetween('scheduled_date', [$startDate, $endDate])
+            ->whereNotIn('status', ['cancelled'])
+            ->with(['items', 'order', 'customer'])
+            ->orderBy('scheduled_date')
+            ->get();
+    }
+} 

--- a/inventory-api/database/migrations/2025_06_24_100000_create_installations_table.php
+++ b/inventory-api/database/migrations/2025_06_24_100000_create_installations_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('installations', function (Blueprint $table) {
+            $table->id();
+            $table->string('installation_number')->unique(); // 安裝單號，獨立編號系統
+            
+            // 關聯鍵（可選，實現鬆耦合）
+            $table->foreignId('order_id')->nullable()->constrained('orders');
+            $table->foreignId('installer_user_id')->nullable()->constrained('users');
+            $table->foreignId('created_by')->constrained('users');
+            
+            // 客戶資訊（冗餘設計，支援非訂單安裝）
+            $table->string('customer_name');
+            $table->string('customer_phone');
+            $table->text('installation_address');
+            
+            // 狀態和時間管理
+            $table->enum('status', [
+                'pending',      // 待處理
+                'scheduled',    // 已排程
+                'in_progress',  // 進行中
+                'completed',    // 已完成
+                'cancelled'     // 已取消
+            ])->default('pending');
+            
+            $table->date('scheduled_date')->nullable(); // 預計安裝日期
+            $table->datetime('actual_start_time')->nullable(); // 實際開始時間
+            $table->datetime('actual_end_time')->nullable(); // 實際結束時間
+            
+            // 備註
+            $table->text('notes')->nullable();
+            
+            $table->timestamps();
+            
+            // 索引
+            $table->index('status');
+            $table->index('scheduled_date');
+            $table->index('installer_user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('installations');
+    }
+}; 

--- a/inventory-api/database/migrations/2025_06_24_100001_create_installation_items_table.php
+++ b/inventory-api/database/migrations/2025_06_24_100001_create_installation_items_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('installation_items', function (Blueprint $table) {
+            $table->id();
+            
+            // 關聯鍵
+            $table->foreignId('installation_id')->constrained('installations')->cascadeOnDelete();
+            $table->foreignId('order_item_id')->nullable()->constrained('order_items');
+            
+            // 商品資訊（冗餘設計）
+            $table->string('product_name');
+            $table->string('sku');
+            $table->integer('quantity');
+            $table->text('specifications')->nullable(); // 安裝規格說明
+            
+            // 狀態管理
+            $table->enum('status', [
+                'pending',    // 待安裝
+                'completed'   // 已完成
+            ])->default('pending');
+            
+            // 備註
+            $table->text('notes')->nullable();
+            
+            $table->timestamps();
+            
+            // 索引
+            $table->index('installation_id');
+            $table->index('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('installation_items');
+    }
+}; 

--- a/inventory-api/database/migrations/2025_06_24_100002_create_monthly_installation_counters_table.php
+++ b/inventory-api/database/migrations/2025_06_24_100002_create_monthly_installation_counters_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('monthly_installation_counters', function (Blueprint $table) {
+            $table->id();
+            $table->string('year_month', 7)->unique(); // 格式: YYYY-MM
+            $table->integer('last_sequence')->default(0); // 最後使用的序號
+            $table->timestamps();
+            
+            // 索引
+            $table->index('year_month');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('monthly_installation_counters');
+    }
+}; 

--- a/inventory-api/routes/api.php
+++ b/inventory-api/routes/api.php
@@ -293,5 +293,26 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::prefix('reports')->group(function () {
         Route::get('/inventory-time-series', [App\Http\Controllers\Api\ReportController::class, 'inventoryTimeSeries']);
     });
+
+    /**
+     * 安裝管理路由
+     * 提供安裝單的創建、管理和狀態追蹤功能，支援與訂單系統的鬆耦合整合
+     * 
+     * 路由列表：
+     * GET    /api/installations                            - 獲取安裝單列表（支援狀態/師傅/日期篩選）
+     * POST   /api/installations                            - 創建新安裝單
+     * POST   /api/installations/create-from-order          - 從訂單創建安裝單
+     * GET    /api/installations/schedule                   - 獲取安裝師傅的行程
+     * GET    /api/installations/{installation}             - 獲取指定安裝單詳情
+     * PUT    /api/installations/{installation}             - 更新指定安裝單
+     * DELETE /api/installations/{installation}             - 刪除指定安裝單
+     * POST   /api/installations/{installation}/assign      - 分配安裝師傅
+     * POST   /api/installations/{installation}/status      - 更新安裝單狀態
+     */
+    Route::post('/installations/create-from-order', [App\Http\Controllers\Api\InstallationController::class, 'createFromOrder']);
+    Route::get('/installations/schedule', [App\Http\Controllers\Api\InstallationController::class, 'getSchedule']);
+    Route::apiResource('installations', App\Http\Controllers\Api\InstallationController::class);
+    Route::post('/installations/{installation}/assign', [App\Http\Controllers\Api\InstallationController::class, 'assignInstaller']);
+    Route::post('/installations/{installation}/status', [App\Http\Controllers\Api\InstallationController::class, 'updateStatus']);
 });
  

--- a/安裝管理功能開發文檔.md
+++ b/安裝管理功能開發文檔.md
@@ -1,0 +1,271 @@
+# 安裝管理功能開發文檔
+
+## 功能概述
+
+安裝管理系統是一個獨立的模組，支援兩種建立方式：
+1. 從現有訂單「一鍵導入」建立安裝單
+2. 直接手工建立安裝單（適用於售後安裝、維修等場景）
+
+採用解耦合的系統設計，安裝單可選擇性綁定 order_id，實現鬆耦合關聯。
+
+## 階段一：後端 API 實施完成 ✅
+
+### 實施狀態：已完成並測試通過
+
+#### 測試結果
+- ✅ 成功創建安裝單 (編號: I-202506-0001)
+- ✅ 成功查詢安裝單列表
+- ✅ 成功更新安裝單狀態 (pending → scheduled)
+- ✅ 權限系統正常運作
+
+#### API 文檔同步
+- ✅ 修復了 Scribe 生成文檔的問題（修改了 field-details.blade.php 模板）
+- ✅ 成功生成包含安裝管理 API 的 OpenAPI 文檔
+- ✅ OpenAPI 文檔已同步到前端（inventory-client/openapi.yaml）
+- ✅ 前端 API 類型定義已更新（src/types/api.ts）
+
+#### 注意事項
+1. 已為 User 模型添加 `hasAnyRole()` 方法以支援權限檢查
+2. 已添加 `installer` 角色常數定義
+3. API 功能已全部實現並可正常使用
+4. 修復了 Scribe 處理複雜對象 example 的問題（修改 field-details.blade.php）
+5. **重要原則**：保持後端 API 文檔的完整性，不應為了工具問題而簡化 example
+
+### 1. 資料模型
+
+#### Installation (安裝單主表)
+```php
+- id: 主鍵
+- installation_number: 安裝單號 (格式: I-YYYYMM-XXXX)
+- order_id: 可空，關聯的訂單ID
+- customer_name: 客戶姓名
+- customer_phone: 客戶電話
+- installation_address: 安裝地址
+- installer_user_id: 分配的安裝師傅
+- status: pending|scheduled|in_progress|completed|cancelled
+- scheduled_date: 預計安裝日期
+- actual_start_time: 實際開始時間
+- actual_end_time: 實際結束時間
+- notes: 安裝備註
+- created_by: 建立者
+```
+
+#### InstallationItem (安裝項目)
+```php
+- id: 主鍵
+- installation_id: 安裝單ID
+- order_item_id: 可空，來源訂單項目ID
+- product_name: 商品名稱
+- sku: 商品編號
+- quantity: 安裝數量
+- specifications: 安裝規格說明
+- status: pending|completed
+- notes: 項目備註
+```
+
+### 2. API 端點
+
+#### 安裝單管理
+- `GET /api/installations` - 獲取安裝單列表
+- `POST /api/installations` - 建立新安裝單
+- `GET /api/installations/{id}` - 查看安裝單詳情
+- `PUT /api/installations/{id}` - 更新安裝單
+- `DELETE /api/installations/{id}` - 刪除安裝單
+
+#### 從訂單建立
+- `POST /api/installations/create-from-order` - 從訂單建立安裝單
+
+#### 狀態管理
+- `POST /api/installations/{id}/assign` - 分配安裝師傅
+- `POST /api/installations/{id}/status` - 更新安裝單狀態
+
+#### 行程管理
+- `GET /api/installations/schedule` - 獲取安裝師傅的行程
+
+### 3. 權限設計
+
+#### admin 角色
+- 全部安裝管理權限
+
+#### installer 角色
+- 查看分配給自己的安裝任務
+- 更新安裝進度
+- 查看行事曆
+
+#### staff 角色
+- 建立安裝單
+- 查看所有安裝狀態
+- 分配師傅
+
+#### viewer 角色
+- 僅查看安裝狀態
+
+### 4. 業務邏輯
+
+#### 狀態轉換規則
+```
+pending → scheduled → in_progress → completed
+   ↓           ↓            ↓
+cancelled   cancelled    cancelled
+```
+
+#### 自動化行為
+- 分配師傅時，如果狀態為 pending，自動轉為 scheduled
+- 狀態轉為 in_progress 時，自動記錄開始時間
+- 狀態轉為 completed 時，自動記錄結束時間
+- 所有項目完成時，自動將安裝單標記為完成
+
+### 5. 與訂單系統的整合
+
+- Order 模型新增 `installations()` 關聯方法
+- 支援從訂單一鍵建立安裝單
+- 安裝單可選擇性關聯訂單（鬆耦合設計）
+- 客戶資訊冗餘存儲，支援獨立運作
+
+## 待實施階段
+
+### 階段二：前端安裝管理頁面
+
+#### 實施計劃
+1. **建立前端類型定義**
+   - 在 `inventory-client/src/types/installation.ts` 定義類型
+   - 使用現有的 api-helpers.ts 進行 API 調用
+
+2. **建立 React Query hooks**
+   - `useInstallations` - 查詢安裝單列表
+   - `useInstallation` - 查詢單一安裝單
+   - `useCreateInstallation` - 創建安裝單
+   - `useUpdateInstallation` - 更新安裝單
+
+3. **實現頁面組件**
+   - `/installations` - 安裝單列表頁面 (DataTable + 篩選)
+   - `/installations/[id]` - 安裝單詳情頁面
+   - `/installations/new` - 新增安裝單表單
+   - `/installations/[id]/edit` - 編輯安裝單表單
+
+4. **整合到側邊欄**
+   - 在 app-sidebar.tsx 添加安裝管理選單項目
+
+### 階段三：行事曆功能實現
+- 整合 react-big-calendar
+- 月/週/日視圖切換
+- 拖拽調整時間
+- 衝突檢測和警告
+
+### 階段四：與訂單系統的整合連結
+- 訂單詳情頁面新增「相關安裝」區塊
+- 訂單操作選單新增「建立安裝單」選項
+- 雙向超連結導航
+
+## 技術實施細節
+
+### 使用的設計模式
+1. **Service Layer Pattern**: InstallationService 處理複雜業務邏輯
+2. **Repository Pattern**: 使用 Eloquent ORM
+3. **Policy Pattern**: 細粒度權限控制
+4. **Resource Pattern**: API 資源轉換
+
+### 遵循的架構原則
+1. **契約優先**: 完整的 Request 驗證和 Resource 轉換
+2. **權限分離**: 基於角色的權限控制
+3. **解耦合設計**: 安裝系統可獨立於訂單系統運作
+4. **資料冗餘**: 關鍵資訊冗餘存儲，確保系統穩定性
+
+## API 使用範例
+
+### 建立安裝單
+```json
+POST /api/installations
+{
+    "customer_name": "王小明",
+    "customer_phone": "0912345678",
+    "installation_address": "台北市信義區信義路五段7號",
+    "scheduled_date": "2025-06-25",
+    "items": [
+        {
+            "product_name": "辦公桌",
+            "sku": "DESK-001",
+            "quantity": 2,
+            "specifications": "靠窗安裝"
+        }
+    ]
+}
+```
+
+### 從訂單建立安裝單
+```json
+POST /api/installations/create-from-order
+{
+    "order_id": 1,
+    "order_item_ids": [1, 2, 3],
+    "scheduled_date": "2025-06-25",
+    "installer_user_id": 2
+}
+```
+
+### 更新安裝狀態
+```json
+POST /api/installations/1/status
+{
+    "status": "in_progress"
+}
+```
+
+## Scribe 文檔生成錯誤修復記錄（2025-06-24）
+
+### 修復的問題
+
+1. **UpdateCustomerRequest 路由參數錯誤**
+   - 錯誤：`Attempt to read property "id" on null`
+   - 原因：直接訪問 `$this->route('customer')->id` 時沒有檢查 null
+   - 修復：添加 null 檢查
+   ```php
+   $customer = $this->route('customer');
+   $customerId = $customer ? $customer->id : null;
+   ```
+
+2. **缺少 bodyParameters() 方法的 Request 類**
+   - 修復了以下 Request 類：
+     - BatchDeleteOrdersRequest
+     - BatchUpdateStatusRequest
+     - StoreProductRequest（已有）
+     - AddPaymentRequest
+     - CreateInstallationFromOrderRequest
+     - UpdateCustomerRequest
+     - UploadProductImageRequest
+     - UpdateOrderRequest
+     - CreateRefundRequest
+     - UpdateOrderItemStatusRequest
+     - InventoryTimeSeriesRequest
+     - StoreInstallationRequest
+     - UpdateInstallationRequest
+
+### 修復方法
+
+為每個缺少 `bodyParameters()` 方法的 Request 類添加了該方法，格式如下：
+
+```php
+/**
+ * 取得請求體參數的文檔
+ * 
+ * 用於 Scribe API 文檔生成
+ * 
+ * @return array
+ */
+public function bodyParameters(): array
+{
+    return [
+        'field_name' => [
+            'description' => '欄位描述',
+            'example' => '範例值',
+        ],
+        // ... 其他欄位
+    ];
+}
+```
+
+### 結果
+
+- 所有 Scribe 文檔生成錯誤已修復
+- API 文檔成功生成：http://localhost/docs
+- OpenAPI 規格檔案成功生成：storage/app/private/scribe/openapi.yaml 


### PR DESCRIPTION
- 新增了 Installation 和 InstallationItem 模型，並新增了用於狀態管理的關係和方法。
- 創建了 InstallationPolicy，用於基於使用者角色進行存取控制。
- 開發了 InstallationNumberGenerator 服務，用於產生唯一的安裝編號。
- 實作了 InstallationService，用於處理安裝的建立、更新和狀態管理。
- 為安裝、安裝項目和每月安裝計數器建立了遷移。
- 定義了用於安裝管理的 API 路由，包括根據訂單建立和狀態更新。
- 更新了 User 模型，使其包含安裝者角色和角色檢查方法。
- 在新的 Markdown 檔案中記錄了安裝管理功能及其 API。