### PR TITLE
Fix: 修復 Cloud Run 配額限制問題

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,7 @@ jobs:
             --memory=512Mi \
             --cpu=1 \
             --min-instances=0 \
-            --max-instances=100
+            --max-instances=5
             
       - name: 'Update API URL Environment Variable'
         run: |-
@@ -230,7 +230,12 @@ jobs:
             --region=${{ env.REGION }} \
             --platform=managed \
             --allow-unauthenticated \
-            --set-env-vars="NEXT_PUBLIC_API_BASE_URL=${{ steps.get_api_url.outputs.API_URL }}"
+            --set-env-vars="NEXT_PUBLIC_API_BASE_URL=${{ steps.get_api_url.outputs.API_URL }}" \
+            --timeout=60 \
+            --memory=512Mi \
+            --cpu=1 \
+            --min-instances=0 \
+            --max-instances=5
 
       - name: 'Display Deployment URLs'
         run: |-


### PR DESCRIPTION
- 將最大實例數從 100 降低為 5 以符合 GCP 配額限制
- 為 API 和 Client 服務都設定相同的資源限制
- 避免超出 MaxInstancesLimitPerProjectRegion 和 CPU/記憶體配額

🤖 Generated with [Claude Code](https://claude.ai/code)