### PR TITLE
Fix: 修復容器啟動和端口監聽問題

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,11 +139,11 @@ jobs:
             --add-cloudsql-instances=${{ env.CLOUD_SQL_CONNECTION_NAME }} \
             --set-env-vars="APP_ENV=production,APP_NAME=庫存管理系統,APP_DEBUG=false,APP_TIMEZONE=Asia/Taipei,DB_CONNECTION=mysql,DB_HOST=/cloudsql/${{ env.CLOUD_SQL_CONNECTION_NAME }},DB_PORT=3306,DB_DATABASE=lomis_internal,DB_USERNAME=h1431532403240,FRONTEND_URL=${{ steps.get_client_url.outputs.CLIENT_URL }},SESSION_DOMAIN=.lomis.com.tw,SANCTUM_STATEFUL_DOMAINS=www.lomis.com.tw,FILESYSTEM_DISK=gcs,GCS_BUCKET=${{ env.GCS_BUCKET }},GOOGLE_CLOUD_PROJECT_ID=${{ env.PROJECT_ID }},CACHE_STORE=file,SESSION_DRIVER=file,SESSION_LIFETIME=120,QUEUE_CONNECTION=sync,APP_LOCALE=zh_TW,LOG_CHANNEL=stack,LOG_LEVEL=error,SPATIE_PERMISSION_CACHE_EXPIRATION_TIME=3600" \
             --set-secrets="LARAVEL_APP_KEY=LARAVEL_APP_KEY:latest,LARAVEL_DB_PASSWORD=LARAVEL_DB_PASSWORD:latest" \
-            --timeout=60 \
-            --memory=512Mi \
+            --timeout=300 \
+            --memory=1Gi \
             --cpu=1 \
             --min-instances=0 \
-            --max-instances=5
+            --max-instances=3
             
       - name: 'Update API URL Environment Variable'
         run: |-
@@ -231,11 +231,11 @@ jobs:
             --platform=managed \
             --allow-unauthenticated \
             --set-env-vars="NEXT_PUBLIC_API_BASE_URL=${{ steps.get_api_url.outputs.API_URL }}" \
-            --timeout=60 \
-            --memory=512Mi \
+            --timeout=300 \
+            --memory=1Gi \
             --cpu=1 \
             --min-instances=0 \
-            --max-instances=5
+            --max-instances=3
 
       - name: 'Display Deployment URLs'
         run: |-

--- a/inventory-api/Dockerfile
+++ b/inventory-api/Dockerfile
@@ -43,6 +43,11 @@ RUN composer install --no-dev --optimize-autoloader
 # 複製 Nginx 配置
 COPY docker/nginx/default.conf /etc/nginx/sites-available/default
 
+# 移除預設的 Nginx 配置並創建必要的目錄
+RUN rm -f /etc/nginx/sites-enabled/default \
+    && mkdir -p /etc/nginx/sites-enabled \
+    && mkdir -p /var/log/nginx
+
 # 複製 Supervisor 配置
 COPY docker/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/inventory-api/docker/entrypoint.sh
+++ b/inventory-api/docker/entrypoint.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
 set -e
 
+echo "🚀 啟動容器..."
+echo "環境變數 PORT: $PORT"
+
 # Cloud Run 特殊處理
 if [ -n "$PORT" ]; then
     echo "檢測到 Cloud Run 環境，PORT=$PORT"
     # 動態設置 Nginx 監聽端口
+    echo "修改 Nginx 配置以監聽端口 $PORT..."
     sed -i "s/listen 8080;/listen $PORT;/g" /etc/nginx/sites-available/default
+    echo "✅ Nginx 配置已更新"
+    
+    # 顯示修改後的配置
+    echo "📋 Nginx 配置檢查："
+    grep "listen" /etc/nginx/sites-available/default
+else
+    echo "使用預設端口 8080"
 fi
 
 # 簡化版本：不等待資料庫，讓 Cloud Run 健康檢查處理
@@ -43,6 +54,14 @@ php artisan scribe:generate || true
 
 # 確保權限正確
 chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache
+
+# 啟用 Nginx 站點
+echo "啟用 Nginx 站點..."
+ln -sf /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+
+# 測試 Nginx 配置
+echo "測試 Nginx 配置..."
+nginx -t
 
 # 啟動 Supervisor
 echo "啟動應用程式..."


### PR DESCRIPTION
- 增加 entrypoint.sh 調試信息和 Nginx 站點啟用
- 修改 Dockerfile 確保 Nginx 目錄結構正確
- 增加啟動超時時間從 60 秒到 300 秒
- 調整記憶體配置從 512Mi 到 1Gi
- 降低最大實例數為 3 以符合配額限制
- 添加 Nginx 配置測試確保正確性

🤖 Generated with [Claude Code](https://claude.ai/code)