### PR TITLE
Fix: 修復 Cloud Run Jobs 創建和執行問題

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,17 +155,24 @@ jobs:
 
       - name: 'Run Database Migrations'
         run: |-
-          gcloud run jobs create ${{ env.API_SERVICE_NAME }}-migrate \
-            --region=${{ env.REGION }} \
-            --image=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.API_SERVICE_NAME }}-repo/api:latest \
-            --command=php \
-            --args=artisan,migrate,--force \
-            --add-cloudsql-instances=${{ env.CLOUD_SQL_CONNECTION_NAME }} \
-            --set-env-vars="APP_ENV=production,DB_CONNECTION=mysql,DB_HOST=/cloudsql/${{ env.CLOUD_SQL_CONNECTION_NAME }},DB_PORT=3306,DB_DATABASE=lomis_internal,DB_USERNAME=h1431532403240" \
-            --set-secrets="LARAVEL_APP_KEY=LARAVEL_APP_KEY:latest,LARAVEL_DB_PASSWORD=LARAVEL_DB_PASSWORD:latest" \
-            --task-timeout=300 \
-            --parallelism=1 \
-            --max-retries=1 || echo "Migration job already exists"
+          echo "創建或更新資料庫遷移 Job..."
+          if gcloud run jobs describe ${{ env.API_SERVICE_NAME }}-migrate --region=${{ env.REGION }} >/dev/null 2>&1; then
+            echo "更新現有的遷移 Job..."
+            gcloud run jobs replace-job --region=${{ env.REGION }} --image=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.API_SERVICE_NAME }}-repo/api:latest ${{ env.API_SERVICE_NAME }}-migrate
+          else
+            echo "創建新的遷移 Job..."
+            gcloud run jobs create ${{ env.API_SERVICE_NAME }}-migrate \
+              --region=${{ env.REGION }} \
+              --image=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.API_SERVICE_NAME }}-repo/api:latest \
+              --command=php \
+              --args=artisan,migrate,--force \
+              --set-cloudsql-instances=${{ env.CLOUD_SQL_CONNECTION_NAME }} \
+              --set-env-vars="APP_ENV=production,DB_CONNECTION=mysql,DB_HOST=/cloudsql/${{ env.CLOUD_SQL_CONNECTION_NAME }},DB_PORT=3306,DB_DATABASE=lomis_internal,DB_USERNAME=h1431532403240" \
+              --set-secrets="LARAVEL_APP_KEY=LARAVEL_APP_KEY:latest,LARAVEL_DB_PASSWORD=LARAVEL_DB_PASSWORD:latest" \
+              --task-timeout=300 \
+              --parallelism=1 \
+              --max-retries=1
+          fi
           
           echo "執行資料庫遷移..."
           gcloud run jobs execute ${{ env.API_SERVICE_NAME }}-migrate --region=${{ env.REGION }} --wait


### PR DESCRIPTION
- 修正參數從 --add-cloudsql-instances 改為 --set-cloudsql-instances
- 增加 Job 存在性檢查，避免嘗試執行不存在的 Job
- 使用 gcloud run jobs replace-job 更新現有 Job
- 改善錯誤處理邏輯，確保 Job 創建成功後才執行

🤖 Generated with [Claude Code](https://claude.ai/code)