### PR TITLE
feat: 實作 CI/CD 中的 OpenAPI 規格生成流程

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,24 @@
       "Bash(php artisan tinker:*)",
       "WebFetch(domain:scribe.knuckles.wtf)",
       "Bash(./prepare-gcp-deployment.sh:*)",
-      "Bash(./deploy-to-gcp.sh:*)"
+      "Bash(./deploy-to-gcp.sh:*)",
+      "Bash(docker build:*)",
+      "Bash(composer install:*)",
+      "Bash(git add:*)",
+      "Bash(gcloud iam service-accounts list:*)",
+      "Bash(gh secret set:*)",
+      "Bash(gcloud iam workload-identity-pools describe:*)",
+      "Bash(gcloud iam workload-identity-pools providers describe:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gcloud projects add-iam-policy-binding:*)",
+      "Bash(--member=\"serviceAccount:672374290013-compute@developer.gserviceaccount.com\" )",
+      "Bash(--role=\"roles/secretmanager.secretAccessor\")",
+      "Bash(--member=\"serviceAccount:github-deploy-sa@turnkey-pottery-461707-b5.iam.gserviceaccount.com\" )",
+      "Bash(--role=\"roles/resourcemanager.projectIamAdmin\")",
+      "Bash(git push:*)",
+      "Bash(git pull:*)",
+      "Bash(git stash:*)",
+      "Bash(npm run build:*)"
     ],
     "deny": []
   }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -302,6 +302,34 @@ jobs:
             echo "使用 Cloud Run URL: ${API_URL}"
           fi
 
+      - name: 'Generate OpenAPI Specification'
+        run: |-
+          echo "📄 生成 OpenAPI 規格..."
+          # 等待 API 服務完全啟動
+          sleep 10
+          
+          # 嘗試下載 OpenAPI 規格
+          max_retries=5
+          retry_count=0
+          
+          while [ $retry_count -lt $max_retries ]; do
+            echo "嘗試從 ${{ steps.get_api_url.outputs.API_URL }}/docs.openapi 下載 OpenAPI 規格 (嘗試 $((retry_count + 1))/$max_retries)..."
+            
+            if curl -f -o ./inventory-client/openapi.yaml "${{ steps.get_api_url.outputs.API_URL }}/docs.openapi"; then
+              echo "✅ 成功下載 OpenAPI 規格"
+              ls -la ./inventory-client/openapi.yaml
+              break
+            else
+              echo "❌ 下載失敗，等待 10 秒後重試..."
+              sleep 10
+              retry_count=$((retry_count + 1))
+            fi
+          done
+          
+          if [ ! -f ./inventory-client/openapi.yaml ]; then
+            echo "⚠️ 無法下載 OpenAPI 規格，將使用基本類型檔案"
+          fi
+
       - name: 'Build and Push Client Docker Image'
         run: |-
           gcloud artifacts repositories create ${{ env.CLIENT_SERVICE_NAME }}-repo \

--- a/inventory-client/Dockerfile
+++ b/inventory-client/Dockerfile
@@ -16,6 +16,9 @@ RUN npm ci
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+# 安裝 curl 來下載 OpenAPI 規格
+RUN apk add --no-cache curl
+
 # 複製依賴
 COPY --from=deps /app/node_modules ./node_modules
 
@@ -28,6 +31,27 @@ ENV NEXT_TELEMETRY_DISABLED 1
 # 設定建置時 API URL 參數（用於 GCP 部署）
 ARG NEXT_PUBLIC_API_BASE_URL
 ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+
+# 檢查是否有從 CI/CD 流程提供的 openapi.yaml
+# 如果有，使用它來生成完整的 TypeScript 類型
+# 如果沒有，建立基本的類型檔案以確保建置成功
+RUN if [ -f "openapi.yaml" ]; then \
+      echo "✅ 找到 openapi.yaml，生成 TypeScript API 類型..." && \
+      npm run api:types && \
+      echo "✅ API 類型生成完成"; \
+    else \
+      echo "⚠️ 找不到 openapi.yaml，建立基本類型檔案..." && \
+      mkdir -p src/types && \
+      echo "// Auto-generated API types (fallback)" > src/types/api.ts && \
+      echo "export interface paths {" >> src/types/api.ts && \
+      echo "  '/api/auth/login': any;" >> src/types/api.ts && \
+      echo "  '/api/auth/logout': any;" >> src/types/api.ts && \
+      echo "  '/api/auth/user': any;" >> src/types/api.ts && \
+      echo "}" >> src/types/api.ts && \
+      echo "export interface components {" >> src/types/api.ts && \
+      echo "  schemas: {};" >> src/types/api.ts && \
+      echo "}" >> src/types/api.ts; \
+    fi
 
 # 構建應用程式
 RUN npm run build


### PR DESCRIPTION
- 在 GitHub Actions 中新增步驟，從已部署的後端 API 下載 OpenAPI 規格
- 修改前端 Dockerfile，使用 CI/CD 提供的 openapi.yaml 生成 TypeScript 類型
- 如果無法獲取 OpenAPI 規格，使用基本類型檔案確保建置成功
- 保持 src/types/api.ts 不在版本控制中，適合多人協作
- 前後端 API 定義自動同步

🤖 Generated with [Claude Code](https://claude.ai/code)